### PR TITLE
Without the .ToString() the data object is empty

### DIFF
--- a/Instructions/Labs/AZ-204_10_lab.md
+++ b/Instructions/Labs/AZ-204_10_lab.md
@@ -273,7 +273,7 @@ In this exercise, you created a new subscription, validated its registration, an
             EventType = "Employees.Registration.New",
             EventTime = DateTime.Now,
             Subject = $"New Employee: {firstPerson.FullName}",
-            Data = firstPerson,
+            Data = firstPerson.ToString(),
             DataVersion = "1.0.0"
         };
         events.Add(firstEvent);
@@ -294,7 +294,7 @@ In this exercise, you created a new subscription, validated its registration, an
             EventType = "Employees.Registration.New",
             EventTime = DateTime.Now,
             Subject = $"New Employee: {secondPerson.FullName}",
-            Data = secondPerson,
+            Data = secondPerson.ToString(),
             DataVersion = "1.0.0"
         };
         events.Add(secondEvent);


### PR DESCRIPTION
The event which shows up in the vent grid viewer has an empty data section without adding the ToString. This is likely an issue with the gridviewer itself, but I figured a PR is a better way to report this/
