### PR TITLE
Output vs Select

### DIFF
--- a/Instructions/Labs/AZ-204_09_lab_ak.md
+++ b/Instructions/Labs/AZ-204_09_lab_ak.md
@@ -284,7 +284,7 @@ In this exercise, you created all the resources that you'll use for this lab.
 
     1.  In the **Status Code** text box, enter **200**.
 
-    1.  On the **Body** field, in the **Dynamic content** list, within the **Output** category, select **Select**.
+    1.  On the **Body** field, in the **Dynamic content** list, within the **Select** category, select **Output**.
 
 1.  In the **Designer** area, select **Save**.
 


### PR DESCRIPTION
"Within the Output category, select Select, "
should be 
"Within the Select category, select Output."

# Module: 09
## Lab/Demo: Exercise 2
### Task 4
#### Step 2

Fixes # .
"Within the Select category, select Output."

Changes proposed in this pull request:

-
-
-