### PR TITLE
Az204 lab3 fix

### DIFF
--- a/Instructions/Labs/AZ-204_03_lab.md
+++ b/Instructions/Labs/AZ-204_03_lab.md
@@ -421,6 +421,10 @@ In this exercise, you accessed existing containers by using the Storage SDK.
     ```
     string uploadedBlobName = "graph.svg";
     ```
+1.  In the **Main** method, update ```await GetContainerAsync(serviceClient, newContainerName);``` to assign returned returned container to a variable named *containerClient*
+    ```
+    BlobContainerClient containerClient = await GetContainerAsync(serviceClient, newContainerName);
+    ```
 
 1.  In the **Main** method, add a new line of code to invoke the **GetBlobAsync** method, passing in the *containerClient* and *uploadedBlobName* variables as parameters and store the result in a variable named *blobClient* of type **BlobClient**:
 

--- a/Instructions/Labs/AZ-204_03_lab.md
+++ b/Instructions/Labs/AZ-204_03_lab.md
@@ -421,7 +421,7 @@ In this exercise, you accessed existing containers by using the Storage SDK.
     ```
     string uploadedBlobName = "graph.svg";
     ```
-1.  In the **Main** method, update ```await GetContainerAsync(serviceClient, newContainerName);``` to assign returned returned container to a variable named *containerClient*
+1.  Update the **Main** method, to assign the response of ```GetContainerAsync``` function to a **BlobContainerClinet** variable named *containerClient*
     ```
     BlobContainerClient containerClient = await GetContainerAsync(serviceClient, newContainerName);
     ```


### PR DESCRIPTION
# Module: 03
## Lab: Retrieving Azure Storage resources and metadata by using the Azure Storage SDK for .NET
###Task: Exercise 4, Task 4: Access blob URI by using the SDK
Fixes #23 .

Changes proposed in this pull request:
Added a step to show a users on how to update Main method to assign the response of GetContainerAsync as a containerClient variable.

See Line number 27 in the attached screenshot:
![image](https://user-images.githubusercontent.com/4143738/78090090-c40da400-738e-11ea-9f7d-8aad765fe1ed.png)
