### PR TITLE
Add import firewall error hint

### DIFF
--- a/Instructions/Labs/AZ-204_04_lab.md
+++ b/Instructions/Labs/AZ-204_04_lab.md
@@ -186,6 +186,8 @@ In this exercise, you created all the Azure resources that you'll need for a pol
 
     > **Note**: Wait for the database to be created before you continue with this lab.
 
+    > **Note**: If you receive a firewall-related error on the import step, it means you did not correctly configure the **Allow Azure services to access server** setting on your SQL Server earlier in the lab.  Review your settings, delete the empty **AdventureWorks** database, and try your import again.
+
 #### Task 4: Use an imported SQL database
 
 1.  Go back to the blade for the **polysqlsrvr*[yourname]*** SQL server resource.

--- a/Instructions/Labs/AZ-204_04_lab_ak.md
+++ b/Instructions/Labs/AZ-204_04_lab_ak.md
@@ -307,6 +307,8 @@ In this exercise, you created all the Azure resources that you'll need for a pol
 
     > **Note**: Wait for the database to be created before you continue with this lab.
 
+    > **Note**: If you receive a firewall-related error on the import step, it means you did not correctly configure the **Allow Azure services to access server** setting on your SQL Server earlier in the lab.  Review your settings, delete the empty **AdventureWorks** database, and try your import again.
+    
 #### Task 4: Use an imported SQL database
 
 1.  In the Azure portal's navigation pane, select the **Resource groups** link.


### PR DESCRIPTION
# Module: 4
## Lab/Demo: 4

Changes proposed in this pull request:

- Adding a hint if the import fails due to a firewall error, just based on student experience with them often missing the appropriate setting.

The phrasing can likely be improved, but this at least gets something in there.