### PR TITLE
.NET Core Version updated

### DIFF
--- a/Instructions/Labs/AZ-204_01_lab.md
+++ b/Instructions/Labs/AZ-204_01_lab.md
@@ -108,7 +108,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
 
     -   Publish: **Code**
 
-    -	Runtime stack: **.NET Core 3.0**
+    -	Runtime stack: **.NET Core 3.1**
 
     -	Operating System: **Windows**
 
@@ -208,7 +208,7 @@ In this exercise, you created a web app in Azure and then deployed your ASP.NET 
 
     -   Publish: **Code**
 
-    -	Runtime stack: **.NET Core 3.0**
+    -	Runtime stack: **.NET Core 3.1**
 
     -	Operating system: **Windows**
 


### PR DESCRIPTION
.NET Core 3.0 is not available anymore, changed to 3.1

# Module: 01
## Lab: 01

Increased .NET Core version from 3.0 to 3.1 as 3.0 is not available anymore in the portal.