### PR TITLE
ACR Access Keys not required

### DIFF
--- a/Instructions/Labs/AZ-204_05_lab.md
+++ b/Instructions/Labs/AZ-204_05_lab.md
@@ -332,19 +332,7 @@ In this exercise, you created a .NET console application to display a machine’
 
 #### Task 3: Manually deploy a container image to Container Instances
 
-1.  Access the container registry that you created earlier in this lab.
-
-1.  Select the **Access keys** link to find the credentials necessary to access your container registry from another service. Record the following values from this section to use later in this lab:
-    
-    -	**Login server**
-
-    -	**Username**
-
-    -	**Password**
-
-    > **Note**: You'll use these values later when you create another container instance.
-
-1.  Create a new container instance with the following information using the **Access keys** credentials that you recorded earlier in this lab:
+1.  Create a new container instance with the following information :
 
     -	Resource group: **ContainerCompute**
     


### PR DESCRIPTION
Taking out the steps to retrieve the Access Keys to access ACR in Exercise 3 - Task 3.
Not required as Admin User was enabled previously in task 1, this creates confusion to some learners.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-