### PR TITLE
updating .net core version

### DIFF
--- a/Instructions/Labs/AZ-204_01_lab_ak.md
+++ b/Instructions/Labs/AZ-204_01_lab_ak.md
@@ -159,7 +159,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
 
     1.  In the **Publish** section, select **Code**.
 
-    1.  In the **Runtime stack** drop-down list, select **.NET Core 3.0 (current)**.
+    1.  In the **Runtime stack** drop-down list, select **.NET Core 3.1 (LTS)**.
 
     1.  In the **Operating System** section, select **Windows**.
 


### PR DESCRIPTION
.Net Core 3.0 is no longer and option. Best match is now ".Net Core 3.1 (LTS)".

# Module: 01
## Lab/Demo: 01

Fixes # .

Changes proposed in this pull request:

-
-
-