### PR TITLE
Cloud Shell upgraded to DotNet 3.1

### DIFF
--- a/Instructions/Labs/AZ-204_05_lab_ak.md
+++ b/Instructions/Labs/AZ-204_05_lab_ak.md
@@ -293,8 +293,8 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1.  Copy and paste the following code into the **Dockerfile** file:
 
     ```
-    # Start using the .NET Core 2.2 SDK container image
-    FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build
+    # Start using the .NET Core 3.1 SDK container image
+    FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 
     # Change current working directory
     WORKDIR /app


### PR DESCRIPTION
Cloud Shell upgraded to DotNet 3.1 so the Dockerfile is updated.

# Module: 05
## Lab/Demo: 5
## Exercise 2
## Task 2

Fixes # .
Updated dockerfile to dotnet 3.1
Changes proposed in this pull request:

-
-
-