### PR TITLE
Corrected resource type from "app" to subscription

### DIFF
--- a/Instructions/Labs/AZ-204_10_lab_ak.md
+++ b/Instructions/Labs/AZ-204_10_lab_ak.md
@@ -235,7 +235,7 @@ In this exercise, you created the Event Grid topic and a web app that you will u
 
     1.  Select **Create**.
   
-    > **Note**: Wait for Azure to finish creating the subscription before you continue with the lab. You'll receive a notification when the app is created.
+    > **Note**: Wait for Azure to finish creating the subscription before you continue with the lab. You'll receive a notification when the subscription is created.
 
 #### Task 3: Observe the subscription validation event
 


### PR DESCRIPTION
# Module: 10
## Lab/Demo: 10 (AK)

Fixes # .

Changes proposed in this pull request:

Corrected resource type from "app" to "subscription" to avoid confusion