### PR TITLE
Update AZ-204_01_lab_ak.md

### DIFF
--- a/Instructions/Labs/AZ-204_01_lab_ak.md
+++ b/Instructions/Labs/AZ-204_01_lab_ak.md
@@ -85,7 +85,11 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
     
     1.  In the **Replication** list, select **Locally-redundant storage (LRS)**.
     
-    1.  In the **Access tier (default)** section, ensure that **Hot** is selected.
+    1.  Select **Next** and keep the default values
+
+1.  Under the **Advanced** tab, perform the following actions:
+        
+    1.  In the **Blob access tier (default)** section, ensure that **Hot** is selected.
     
     1.  Select **Review + Create**.
 


### PR DESCRIPTION
Blob access tier options moved to Advanced tab instead of Basics, updated instructions to reflect the change

# Module: 01
## Lab/Demo: 01

Fixes # 1

Changes proposed in this pull request:

- Blob access tiers moves tot he Advanced sections instead of Basics
- This causes confusion to some learners, so I updated the instructions to reflect the change
