### PR TITLE
Update AZ-204_01_lab_ak.md

### DIFF
--- a/Instructions/Labs/AZ-204_01_lab_ak.md
+++ b/Instructions/Labs/AZ-204_01_lab_ak.md
@@ -85,8 +85,6 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
     
     1.  In the **Replication** list, select **Locally-redundant storage (LRS)**.
     
-    1.  In the **Access tier (default)** section, ensure that **Hot** is selected.
-    
     1.  Select **Review + Create**.
 
 1.  From the **Review + Create** tab, review the options that you specified in the previous steps.


### PR DESCRIPTION
Removed access Tier option included in the creation of Storage Account as it has been removed in the latest Azure UI.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-