### PR TITLE
Update Module 05, Lab05 Dockerfile to use .NET Core 3.1 image

### DIFF
--- a/Instructions/Labs/AZ-204_05_lab.md
+++ b/Instructions/Labs/AZ-204_05_lab.md
@@ -206,8 +206,8 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1.  Open the **Dockerfile** file in the graphical editor, replace its contents with the following code, and then save the file:
 
     ```
-    # Start using the .NET Core 2.2 SDK container image
-    FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build
+    # Start using the .NET Core 3.1 SDK container image
+    FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 
     # Change current working directory
     WORKDIR /app

--- a/Instructions/Labs/AZ-204_05_lab_ak.md
+++ b/Instructions/Labs/AZ-204_05_lab_ak.md
@@ -293,8 +293,8 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1.  Copy and paste the following code into the **Dockerfile** file:
 
     ```
-    # Start using the .NET Core 2.2 SDK container image
-    FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build
+    # Start using the .NET Core 3.1 SDK container image
+    FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 
     # Change current working directory
     WORKDIR /app


### PR DESCRIPTION
# Module: 05
## Lab/Demo: 05

Fixes: Running `dotnet new console --output . --name ipcheck` in Azure Cloud Shell as specified in the lab instructions will create a project targetting .NET Core 3.1. Currently the base image in the Dockerfile is incompatible with this version.

Changes proposed in this pull request:

- Updated the Dockerfile code in the lab 05 instructions