### PR TITLE
Update AZ-204_11_lab_ak.md

### DIFF
--- a/Instructions/Labs/AZ-204_11_lab_ak.md
+++ b/Instructions/Labs/AZ-204_11_lab_ak.md
@@ -199,6 +199,7 @@ In this exercise, you created a new Azure Storage account that you'll use throug
     using Azure.Storage.Queues;
     using Azure.Storage.Queues.Models;
     using System;
+    using System.Text;
     using System.Threading.Tasks;
 
     public class Program
@@ -346,7 +347,7 @@ In this exercise, you configured your .NET project to access the Storage service
 
         foreach(QueueMessage message in messages?.Value)
         {
-            Console.WriteLine($"[{message.MessageId}]\t{message.MessageText}");
+            Console.WriteLine($"[{message.MessageId}]\t{Encoding.UTF8.GetString(Convert.FromBase64String(message.MessageText))}");
         }
     }
     ```


### PR DESCRIPTION
MessageText property of QueueMessage needs to be decoded because it is Base64 encoded. The result is then passed to Encoding.UTF8.GetString as the parameter.
Include the namespace System.Text to use the "Encoding.UTF8.GetString" function.

# Module: 11
## Lab: 11

Fixes # .

Changes proposed in this pull request:

- Imported System.Text namespace
- MessageText property of QueueMessage needs to be decoded,
    Encoding.UTF8.GetString(Convert.FromBase64String(message.MessageText))