### PR TITLE
az acr list needs resource-group parameter

### DIFF
--- a/Instructions/Labs/AZ-204_05_lab.md
+++ b/Instructions/Labs/AZ-204_05_lab.md
@@ -242,18 +242,18 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 
 1.  Open a new Cloud Shell instance.
 
-1.  At the **Cloud Shell** command prompt, use the **az acr list** command to get a list of all container registries in your subscription.
+1.  At the **Cloud Shell** command prompt, use the **az acr list --resource-group ContainerCompute** command to get a list of all container registries in your resource group.
 
 1.  Use the following command to output the name of the most recently created container registry:
 
     ```
-    az acr list --query "max_by([], &creationDate).name" --output tsv
+    az acr list --resource-group ContainerCompute --query "max_by([], &creationDate).name" --output tsv
     ```
 
 1.  Use the following command to save the name of the most recently created container registry in a Bash shell variable named *acrName*:
 
     ```
-    acrName=$(az acr list --query "max_by([], &creationDate).name" --output tsv)
+    acrName=$(az acr list --resource-group ContainerCompute --query "max_by([], &creationDate).name" --output tsv)
     ```
 
 1.  Use the following script to render the value of the Bash shell variable *acrName*:


### PR DESCRIPTION
Without including the resource-group az acr list returns an empty list. This is corrected by specifying the resource-group in each instance of the command.

# Module: 204
## Lab/Demo: 05

Fixes # .

Changes proposed in this pull request:
Specifying the resource-group parameter when calling az acr list, and slightly correcting the description to reflect what the initial az acr list command will return.
-
-
-