### PR TITLE
Minor UI change: Add replaced by Create

### DIFF
--- a/Instructions/Labs/AZ-204_01_lab_ak.md
+++ b/Instructions/Labs/AZ-204_01_lab_ak.md
@@ -63,7 +63,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
 
 1.  From the **Storage accounts** blade, get your list of storage account instances.
 
-1.  From the **Storage accounts** blade, select **Add**.
+1.  From the **Storage accounts** blade, select **Create**.
 
 1.  From the **Create storage account** blade, observe the tabs from the blade, such as **Basics**, **Tags**, and **Review + Create**.
 


### PR DESCRIPTION
The button '+Add' to add a new storage account to the Storage Accounts service is replaced by '+Create'

# Module: 01
## Lab/Demo: 01
### Exercise 1
### Task 2

Fixes # .
Minor UI change: +Add is replaced by +Create in the Storage Account services page.

Changes proposed in this pull request:

-
-
-