### PR TITLE
Redo: dotnet add package Microsoft.Azure.Cosmos --version 3.4.1

### DIFF
--- a/Instructions/Labs/AZ-204_04_lab_ak.md
+++ b/Instructions/Labs/AZ-204_04_lab_ak.md
@@ -994,7 +994,20 @@ In this exercise, you used Entity Framework and the .NET SDK for Azure Cosmos DB
     dotnet build
     ```
 
-    > **Note**: If there are any build errors, review the **AdventureWorksCosmosContext.cs** file in the **Allfiles (F):\\Allfiles\\Labs\\04\\Solution\\AdventureWorks\\AdventureWorks.Context** folder.
+    > **Note**: If there are any build errors, review the **AdventureWorksCosmosContext.cs** file in the **Allfiles (F):\\Allfiles\\Labs\\04\\Solution\\AdventureWorks\\AdventureWorks.Context** folder. 
+    > If the error says 
+    ```
+    services.AddScoped<IAdventureWorksProductContext, AdventureWorksCosmosContext>(provider =>
+    new AdventureWorksCosmosContext(
+        _configuration.GetConnectionString(nameof(AdventureWorksCosmosContext))
+    )
+    ```
+    you might need to do 
+     ```
+    dotnet add package Microsoft.Azure.Cosmos --version 3.4.1
+    ```
+    in the current folder.
+);
 
 1.  Select **Kill Terminal** or the **Recycle Bin** icon to close the currently open terminal and any associated processes.
 


### PR DESCRIPTION
I had to redownload Azure cosmos in the Adventureworks Context folder, even though I did it already in the Migrate folder. 
Thought other people might have same issue.

# Module: 04
## Lab/Demo: 04

Fixes # .

Changes proposed in this pull request:

-Update lab instructions to be more clear. 
-Because the issue was not solved just by comparing code with solution code (it was the same)
-It required me to add the package Microsoft.Azure.Cosmos --version 3.4.1 in the Adventureworks.Context folder, even though it was done in AdventureWorks.Migrate. 