### PR TITLE
Fix line number of UseHttpsRedirection()

### DIFF
--- a/Instructions/Labs/AZ-204_11_lab.md
+++ b/Instructions/Labs/AZ-204_11_lab.md
@@ -193,7 +193,7 @@ In this exercise, you created the resources that you'll use for the remainder of
 
 1.  Use the Explorer in Visual Studio Code to open the **Startup.cs** file in the editor.
 
-1.  Find and delete the following line of code at line 39:
+1.  Find and delete the following line of code at line 47:
 
     ```
     app.UseHttpsRedirection();

--- a/Instructions/Labs/AZ-204_11_lab_ak.md
+++ b/Instructions/Labs/AZ-204_11_lab_ak.md
@@ -257,7 +257,7 @@ In this exercise, you created the resources that you'll use for the remainder of
 
 1.  In the **Visual Studio Code** window, in the Explorer pane, select the **Startup.cs** file to open the file in the editor.
 
-1.  In the editor, in the **Startup** class, find and delete the following line of code at line 39:
+1.  In the editor, in the **Startup** class, find and delete the following line of code at line 47:
 
     ```
     app.UseHttpsRedirection();


### PR DESCRIPTION
# Module: 11
## Lab/Demo: Lab 11, Exercise 2, Task 2

Changes proposed in this pull request:
- Fixes line number for generated dotnet project.

When following the exact steps, the line number of `app.UseHttpsRedirection();` is 47, not 39, see generated project:
![line-nr](https://user-images.githubusercontent.com/1068130/115149424-53522c00-a064-11eb-9e7a-905196bc060f.png)

My system: Windows 10 Home (10.0.19041)
Visual Studio: 2019 (16.9.2)
dotnet --version: 5.0.201