### PR TITLE
lab 10 ex 3 uncheck encoding option to read message

### DIFF
--- a/Instructions/Labs/AZ-204_lab_10.md
+++ b/Instructions/Labs/AZ-204_lab_10.md
@@ -424,7 +424,7 @@ In this exercise, you configured your .NET project to access the Storage service
 
     1.  In the **Expires in** drop-down list, select **Hours**.
 
-    1.  In the **Encoding** section, select **UTF8**.
+    1.  Uncheck **Encode message body in Base64**.
 
     1.  Select **OK**.
 


### PR DESCRIPTION
# Module: 10
## Lab/Demo: 10

Fixes # .

Changes proposed in this pull request:

- uncheck encoding option to read message in storage explorer. option provided does not exist!!
-
-