### PR TITLE
VSCode UI updates

### DIFF
--- a/Instructions/Labs/AZ-204_lab_03.md
+++ b/Instructions/Labs/AZ-204_lab_03.md
@@ -184,7 +184,7 @@ In this exercise, you created a couple of placeholder containers in the storage 
 
 1.  In the **File Explorer** window that opens, browse to **Allfiles (F):\\Allfiles\\Labs\\03\\Starter\\BlobManager**, and then select **Select Folder**.
 
-1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Terminal**.
+1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Integrated Terminal**.
 
 1.  At the open command prompt, enter the following command, and then select Enter to create a new .NET project named **BlobManager** in the current folder:
 
@@ -356,7 +356,7 @@ In this exercise, you created a couple of placeholder containers in the storage 
 
 1.  Save the **Program.cs** file.
 
-1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Terminal**.
+1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Integrated Terminal**.
 
 1.  At the open command prompt, enter the following command, and then select Enter to run the .NET web application:
 
@@ -425,7 +425,7 @@ In this exercise, you created a couple of placeholder containers in the storage 
 
 1.  Save the **Program.cs** file.
 
-1.  In the **Visual Studio Code** window, right-click or access the shortcut menu for the Explorer pane, and then select **Open in Terminal**.
+1.  In the **Visual Studio Code** window, right-click or access the shortcut menu for the Explorer pane, and then select **Open in Integrated Terminal**.
 
 1.  At the open command prompt, enter the following command, and then select Enter to run the .NET web application:
 
@@ -525,7 +525,7 @@ In this exercise, you accessed existing containers by using the Azure Storage SD
 
 1.  Save the **Program.cs** file.
 
-1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Terminal**.
+1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Integrated Terminal**.
 
 1.  At the open command prompt, enter the following command, and then select Enter to run the .NET web application:
 
@@ -619,7 +619,7 @@ In this exercise, you accessed existing containers by using the Azure Storage SD
 
 1.  Save the **Program.cs** file.
 
-1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Terminal**.
+1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Integrated Terminal**.
 
 1.  At the open command prompt, enter the following command, and then select Enter to run the .NET web application:
 
@@ -738,7 +738,7 @@ In this exercise, you accessed existing containers by using the Azure Storage SD
 
 1.  Save the **Program.cs** file.
 
-1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Terminal**.
+1.  In the **Visual Studio Code** window, right-click or activate the shortcut menu for the Explorer pane, and then select **Open in Integrated Terminal**.
 
 1.  At the open command prompt, enter the following command, and then select Enter to run the .NET web application:
 


### PR DESCRIPTION
To open the terminal in the latest VSCode versions the option is "Open in Integrated Terminal" instead of "Open in Terminal".

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-