### PR TITLE
Extra spaces in Lab 11.

### DIFF
--- a/Instructions/Labs/AZ-204_lab_11.md
+++ b/Instructions/Labs/AZ-204_lab_11.md
@@ -253,7 +253,7 @@ In this exercise, you created the Azure resources that you'll use for the remain
 
 1.  Starting from a new line, add the following code at the end of the **ConfigureServices** method to configure Application Insights using the provided instrumentation key:
 
-    ```csharp    
+    ```csharp
     services.AddApplicationInsightsTelemetry(INSTRUMENTATION_KEY);
     ```
 


### PR DESCRIPTION
# Module: 11
## Lab/Demo: 11
**Exercise 2**
**Task 2**
**Step 5**

There are extra spaces after the copy text in Lab 11, Exercise 2, Task 2, Step 5 causing the instructions to include the "csharp".
Reference: #319

![image](https://user-images.githubusercontent.com/92067627/139522521-520c5865-807a-4c6b-aa2d-c67646f77b81.png)
