### PR TITLE
Update AZ-204_lab_11.md

### DIFF
--- a/Instructions/Labs/AZ-204_lab_11.md
+++ b/Instructions/Labs/AZ-204_lab_11.md
@@ -452,7 +452,7 @@ In this exercise, you created an API app by using ASP.NET and configured it to s
     | Setting                         | Action                                                       |
     | ------------------------------- | ------------------------------------------------------------ |
     | **Application Insights** slider | Ensure it is set to **Enable**.|
-    | **Instrument your application** section    | Select the **.NET** tab.|
+    | **Instrument your application** section    | Select the **.NET Core ** tab.|
     | **Collection level** section    | Select **Recommended**. |
     | **Profiler** section      | Select **On**.|
     | **Snapshot debugger** section | Select **Off**.|


### PR DESCRIPTION
Exercise 3: Monitor a web API using Application Insights
Task 2: Configure in-depth metric collection for Web Apps
Step 4

The 'Instrument Your Application' section is '.NET Core' instead of '.NET'

# Module: 11
## Lab/Demo: 3

Fixes # .

Changes proposed in this pull request:

- Step 4: The 'Instrument Your Application' section is '.NET Core' instead of '.NET'