### PR TITLE
Lab 04: Bump AdventureWorks.Context Cosmos package version

### DIFF
--- a/Allfiles/Labs/04/Solution/AdventureWorks/AdventureWorks.Context/AdventureWorks.Context.csproj
+++ b/Allfiles/Labs/04/Solution/AdventureWorks/AdventureWorks.Context/AdventureWorks.Context.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Allfiles/Labs/04/Starter/AdventureWorks/AdventureWorks.Context/AdventureWorks.Context.csproj
+++ b/Allfiles/Labs/04/Starter/AdventureWorks/AdventureWorks.Context/AdventureWorks.Context.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes a method not found issue when viewing items in the associated Web project due to a mismatch in Azure Cosmos versions.

# Module: 04
## Lab/Demo: 04

Fixes #331.

Changes proposed in this pull request:

- Using the same Cosmos package version as in the other projects and associated instructions for this lab.