### PR TITLE
Remove the "." in the end of the containers tag.

### DIFF
--- a/Instructions/Labs/AZ-204_lab_08.md
+++ b/Instructions/Labs/AZ-204_lab_08.md
@@ -77,7 +77,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
     | **Options** drop-down list      | Select **Single Container**.           |
     | **Image Source** drop-down list | Select **Docker Hub**.                 |
     | **Access Type** drop-down list  | Select **Public**.                  |
-    | **Image and tag** text box      | Enter **kennethreitz/httpbin:latest**. |
+    | **Image and tag** text box      | Enter **kennethreitz/httpbin:latest** |
 
 1.  On the **Review + create** tab, review the options that you selected during the previous steps.
 


### PR DESCRIPTION

# Module: 8
## Lab/Demo: 8

Fixes # 1

Changes proposed in this pull request:

Most of the students who is not proficient in the containers copy&paste the` kennethreitz/httpbin:lates.` tag with dot and then get error and spend lots of time for debug.
