### PR TITLE
 Lab_02 - Remove reference to *empty* func directory

### DIFF
--- a/Instructions/Labs/AZ-204_lab_02.md
+++ b/Instructions/Labs/AZ-204_lab_02.md
@@ -176,7 +176,7 @@ In this exercise, you created all the resources that you'll use in this lab.
 #### Task 3: Build and validate a project
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -197,7 +197,7 @@ In this exercise, you created a local project that you'll use for Azure Function
 #### Task 1: Create an HTTP-triggered function
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -373,7 +373,7 @@ In this exercise, you created a local project that you'll use for Azure Function
 #### Task 3: Test the HTTP-triggered function by using httprepl
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -448,7 +448,7 @@ In this exercise, you created a basic function that echoes the content sent thro
 #### Task 1: Create a schedule-triggered function
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -494,7 +494,7 @@ In this exercise, you created a basic function that echoes the content sent thro
 #### Task 3: Observe function runs
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -536,7 +536,7 @@ In this exercise, you created a basic function that echoes the content sent thro
 
 1. On the taskbar, select the **Windows Terminal** icon.
 
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -591,7 +591,7 @@ In this exercise, you created a function that runs automatically based on a fixe
 #### Task 2: Create an HTTP-triggered function
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -753,7 +753,7 @@ In this exercise, you created a function that runs automatically based on a fixe
 #### Task 4: Register Azure Storage Blob extensions
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -776,7 +776,7 @@ In this exercise, you created a function that runs automatically based on a fixe
 #### Task 5: Test the function by using httprepl
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func
@@ -849,7 +849,7 @@ In this exercise, you created a function that returns the content of a JSON file
 #### Task 1: Deploy using the Azure Functions Core Tools
 
 1. On the taskbar, select the **Windows Terminal** icon.
-1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** empty directory:
+1. Run the following command to change the current directory to the **Allfiles (F):\\Allfiles\\Labs\\02\\Starter\\func** directory:
 
     ```powershell
     cd F:\Allfiles\Labs\02\Starter\func


### PR DESCRIPTION
# Module: 2 
## Lab: 2

Changes proposed in this pull request:

In Ex 2, task 2. The **func** directory is (mostly) empty. 
But *every* reference to this directory in the lab says it is empty.
This removes the word empty from every reference after the first
