### PR TITLE
Lab 11 "dotnet dev-certs https --trust" needed

### DIFF
--- a/Instructions/Labs/AZ-204_lab_11.md
+++ b/Instructions/Labs/AZ-204_lab_11.md
@@ -280,6 +280,7 @@ In this exercise, you created the Azure resources that you'll use for the remain
 1.  At the terminal prompt, run the following command to launch the .NET Web API.
 
     ```
+    dotnet dev-certs https --trust
     dotnet run
     ```
 


### PR DESCRIPTION
# Module: 11
## Lab/Demo: 11

Fixes #361  .

Changes proposed in this pull request:

-dotnet dev-certs https --trust
-
-