### PR TITLE
LAB 12 - EX 02 - TASK 02 - STEP 01/d

### DIFF
--- a/Instructions/Labs/AZ-204_lab_12.md
+++ b/Instructions/Labs/AZ-204_lab_12.md
@@ -170,10 +170,12 @@ In this exercise, you created an Azure Storage account and an Azure Web App that
     d.  Enter the following command, and then select Enter to list only the namespaces of the currently registered providers:
 
      ```bash
-     az provider list --query "[].namespace"
+     az provider list --query "[?registrationState=='Registered'].namespace"
      ```
 
     e.  Observe the list of currently registered providers. The **Microsoft.CDN** provider isn't currently in the list of providers.
+    
+    **Note**: If you have the **Microsoft.Cdn** provider in the registered provider list, you don't need to execute the following commands. The Cdn provider is already registered.
 
     f.  Enter the following command, and then select Enter to get the required flags to register a new provider:
 


### PR DESCRIPTION
The command 'az provider list --query "[].namespace"' shows all the provider in the subscription, not only the registered ones. The right command shuold be 'az provider list --query "[?registrationState=='Registered'].namespace"'

I also added a note regarding the case when you already have the provider registered.