### PR TITLE
AZ-204 Lab04: Rename variable PrimaryKey to PartitionKey

### DIFF
--- a/Allfiles/Labs/04/Solution/AdventureWorks/AdventureWorks.Upload/Program.cs
+++ b/Allfiles/Labs/04/Solution/AdventureWorks/AdventureWorks.Upload/Program.cs
@@ -15,7 +15,7 @@
         private const string AuthorizationKey = "";
         private const string DatabaseName = "Retail";
         private const string ContainerName = "Online";
-        private const string PrimaryKey = "";
+        private const string PartitionKey = "";
         private const string JsonFilePath = "";
 
         static private int amountToInsert;
@@ -35,7 +35,7 @@
 
                 // Configure indexing policy to exclude all attributes to maximize RU/s usage
                 Console.WriteLine($"Creating a container if not already exists...");
-                await database.DefineContainer(Program.ContainerName, PrimaryKey)
+                await database.DefineContainer(Program.ContainerName, PartitionKey)
                         .WithIndexingPolicy()
                             .WithIndexingMode(IndexingMode.Consistent)
                             .WithIncludedPaths()

--- a/Allfiles/Labs/04/Starter/AdventureWorks/AdventureWorks.Upload/Program.cs
+++ b/Allfiles/Labs/04/Starter/AdventureWorks/AdventureWorks.Upload/Program.cs
@@ -15,7 +15,7 @@
         private const string AuthorizationKey = "";
         private const string DatabaseName = "Retail";
         private const string ContainerName = "Online";
-        private const string PrimaryKey = "";
+        private const string PartitionKey = "";
         private const string JsonFilePath = "";
 
         static private int amountToInsert;
@@ -35,7 +35,7 @@
 
                 // Configure indexing policy to exclude all attributes to maximize RU/s usage
                 Console.WriteLine($"Creating a container if not already exists...");
-                await database.DefineContainer(Program.ContainerName, PrimaryKey)
+                await database.DefineContainer(Program.ContainerName, PartitionKey)
                         .WithIndexingPolicy()
                             .WithIndexingMode(IndexingMode.Consistent)
                             .WithIncludedPaths()

--- a/Instructions/Labs/AZ-204_lab_04.md
+++ b/Instructions/Labs/AZ-204_lab_04.md
@@ -212,7 +212,7 @@ In this exercise, you created the Azure resources that you'll need for the polyg
 
 1.  On line 15, set the value of **AuthorizationKey** by replacing the empty string with the **PRIMARY KEY** property of the Cosmos DB account that you recorded earlier in this lab. Ensure that the value is enclosed in double quotes.
 
-1.  On line 18, set the value of **PrimaryKey** by replacing the empty string with **"/Category"**.
+1.  On line 18, set the value of **PartitionKey** by replacing the empty string with **"/Category"**.
 
 1.  On line 19, set the value of **JsonFilePath** by replacing the empty string with **"F:\\\\Allfiles\\\\Labs\\\\04\\\\Starter\\\\AdventureWorks\\\\AdventureWorks.Upload\\\\models.json"**.
 


### PR DESCRIPTION
# Module: AZ-204
## Lab/Demo: 04

Changes proposed in this pull request:

- Rename PrimaryKey variable to PartitionKey as that's what it actually holds and is used for. It was quite confusing that "/Category" is used as a PK here before we realized it really is the PartitionKey.