### PR TITLE
Function app not working due to dotnet 3.1 version

### DIFF
--- a/Instructions/Labs/AZ-204_lab_07.md
+++ b/Instructions/Labs/AZ-204_lab_07.md
@@ -128,7 +128,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
     | **Function App name** text box    | Enter **securefunc**_[yourname]_. |
     | **Publish** section               | Select **Code**.                  |
     | **Runtime stack** drop-down list  | Select **.NET**.                 |
-    | **Version** drop-down list        | Select **3.1**.                   |
+    | **Version** drop-down list        | Select **6**.                   |
     | **Region** drop-down list         | Select the **East US** region.    |
 
     The following screenshot displays the configured settings in the **Create Function App** blade.


### PR DESCRIPTION
# Module: 07: Implement secure cloud solutions
## Lab/Demo: [07: Access resource secrets more securely across services](https://microsoftlearning.github.io/AZ-204-DevelopingSolutionsforMicrosoftAzure/Instructions/Labs/AZ-204_lab_07.html)

Fixes # .

Changes proposed in this pull request:

- Function app creation for dotnet 3.1 is not working, I have to create another function app using dotnet 6 runtime.
As per instruction to create new function app using visual studio code, it always app with latest dotnet runtime.

- also please change below image
(./media/l07_create_function_app.png)
