### PR TITLE
Lab 5 Ex 2 Task 3 - variable value to lower case

### DIFF
--- a/Instructions/Labs/AZ-204_lab_05.md
+++ b/Instructions/Labs/AZ-204_lab_05.md
@@ -306,7 +306,7 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1. At the **Cloud Shell** command prompt in the portal, run the following command to create a variable with a unique value for the Container Registry resource: 
 
     ```bash
-    registryName=conRegistry$RANDOM
+    registryName=conregistry$RANDOM
     ```
 
 1. At the **Cloud Shell** command prompt in the portal, run the following command to verify the name created in the previous step is available: 


### PR DESCRIPTION
When on exercise 2 task 3, executing a variable with an uppercased character in the name, it will report "connected registry name must be lowercase"

# Module: 5
## Lab: 5

Fixes #457


When creating a container registry with az cli and executing a statement with a variable containing an uppercased character in the name, it will report "connected registry name must be lowercase"