### PR TITLE
Mod 5 - Lab 5 - Task 3 - Step 1 & 3 - Registry name must be lowercase error

### DIFF
--- a/Instructions/Labs/AZ-204_lab_05.md
+++ b/Instructions/Labs/AZ-204_lab_05.md
@@ -306,7 +306,7 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1. At the **Cloud Shell** command prompt in the portal, run the following command to create a variable with a unique value for the Container Registry resource: 
 
     ```bash
-    registryName=conRegistry$RANDOM
+    registryName=conregistry$RANDOM
     ```
 
 1. At the **Cloud Shell** command prompt in the portal, run the following command to verify the name created in the previous step is available: 


### PR DESCRIPTION
# Module: 5
## Lab: 5
### Task: 3
#### Step: 1 & 3

When attempting to use the variable created in Step 1 during the execution of Step 3, you receive an error stating that the registry name must be lowercase.

Fixes #459 

Changes proposed in this pull request:

- Minor edit to Lab 5 instructions