### PR TITLE
Corrected name

### DIFF
--- a/Instructions/Labs/AZ-204_lab_05.md
+++ b/Instructions/Labs/AZ-204_lab_05.md
@@ -306,7 +306,7 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1. At the **Cloud Shell** command prompt in the portal, run the following command to create a variable with a unique value for the Container Registry resource: 
 
     ```bash
-    registryName=conRegistry$RANDOM
+    registryName=conregistry$RANDOM
     ```
 
 1. At the **Cloud Shell** command prompt in the portal, run the following command to verify the name created in the previous step is available: 


### PR DESCRIPTION
the name for the Azure Registry needs to be lower case

# Module: 05
## Lab/Demo: 05

Fixes 1 .

Changes proposed in this pull request:

Azure Container Registry name needs to be lowercase