### PR TITLE
Update .Net SDK to 6.0

### DIFF
--- a/Instructions/Labs/AZ-204_lab_05.md
+++ b/Instructions/Labs/AZ-204_lab_05.md
@@ -279,8 +279,8 @@ In this exercise, you used Cloud Shell to create a VM as part of an automated sc
 1.  Copy and paste the following code into the **Dockerfile** file:
 
     ```
-    # Start using the .NET Core 3.1 SDK container image
-    FROM mcr.microsoft.com/dotnet/sdk:3.1-alpine AS build
+    # Start using the .NET Core 6.0 SDK container image
+    FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 
     # Change current working directory
     WORKDIR /app


### PR DESCRIPTION
Default version of .NET SDK on Azure cli has been updated to 6.0 which means we need to update the version used in the Dockerfile.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-