### PR TITLE
Instructions represented on incorrect screen

### DIFF
--- a/Instructions/Labs/AZ-204_lab_07.md
+++ b/Instructions/Labs/AZ-204_lab_07.md
@@ -130,22 +130,15 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
     | **Runtime stack** drop-down list  | Select **.NET** |
     | **Version** drop-down list        | Select **3.1** |
     | **Region** drop-down list         | Select the **East US** region. |
+    | **Operating system** radio buttons | **Select Linux** |
     | **Plan type** drop-down list      | Select **Consumption (Serverless)** |
 
-    The following screenshot displays the configured settings in the **Create Function App** blade.
-
-    ![Screenshot displaying the configured settings on the Create Function App blade](./media/l07_create_function_app.png)
 
 1. On the **Hosting** tab, perform the following actions, and then select **Review + create**:
 
     | Setting | Action |
     | --- | --- |
     | **Storage account** drop-down list | Select the **securestor**_[yourname]_ storage account |
-    | **Operating System** section       | Select **Linux** |    
-
-    The following screenshot displays the configured settings on the **Hosting** tab on the **Create Function App** blade.
-
-    ![Screenshot displaying the configured settings on the Hosting tab on the Create Function App blade ](./media/l07_create_function_app_hosting_tab.png)
 
 1. On the **Review + create** tab, review the options that you selected during the previous steps.
 


### PR DESCRIPTION
# Module: 07
## Lab/Demo: 07

Fixes settings represented on incorrect screen in the Create a function app section.

Changes proposed in this pull request:

- Plan type is on the basics tab
-
-