### PR TITLE
Fixed powershell command to deploy

### DIFF
--- a/Instructions/Labs/AZ-204_lab_11.md
+++ b/Instructions/Labs/AZ-204_lab_11.md
@@ -395,10 +395,10 @@ In this exercise, you created an API app by using ASP.NET and configured it to s
     $webAppName = (Get-AzWebApp -ResourceGroupName MonitoredAssets | Where-Object {$_.Name -like 'smpapi*'})[0] | Select-Object -ExpandProperty Name
     ```
 
-1.  Run the following command to deploy the **api.zip** file you created previously in this task to the web API whose name you identified in the previous step:
+1.  Run the following command to deploy the **api.zip** file you created previously in this task to the web API whose name you identified in the previous step, select **Y** when prompted by the command:
 
     ```powershell
-    Publish-AzWebApp -ResourceGroupName MonitoredAssets -Name $webAppName -ArchivePath api.zip --Force
+    Publish-AzWebApp -ResourceGroupName MonitoredAssets -Name $webAppName -ArchivePath "F:\Allfiles\Labs\11\Starter\Api\bin\Debug\net6.0\api.zip"
     ```
 
     > **Note**: Wait for the deployment to complete before you continue with this lab.


### PR DESCRIPTION
# Module: 11
## Lab/Demo: 11

Fixes #541  .

Changes proposed in this pull request:

- Powershell requires the full path to the api.zip file for deployment, otherwise it defaults to looking in the C:\windows\system directory.
-
-