### PR TITLE
Update lab 9 code in Solution Foder for .NET 6

### DIFF
--- a/Allfiles/Labs/09/Solution/EventPublisher/EventPub.csproj
+++ b/Allfiles/Labs/09/Solution/EventPublisher/EventPub.csproj
@@ -1,9 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.1.0" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.11.0" />
   </ItemGroup>
+
 </Project>

--- a/Allfiles/Labs/09/Solution/EventPublisher/Program.cs
+++ b/Allfiles/Labs/09/Solution/EventPublisher/Program.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Threading.Tasks;
 using Azure;
 using Azure.Messaging.EventGrid;
+using System;
+using System.Threading.Tasks;
 
 public class Program
 {


### PR DESCRIPTION
Fixes #565 

the code and the project file left outdated as we're now on .NET 6 for all the labs but the two files are still on .NET 3.1 runtime.