### PR TITLE
Choose Standard S1 for app service plan

### DIFF
--- a/Instructions/Labs/AZ-204_lab_01.md
+++ b/Instructions/Labs/AZ-204_lab_01.md
@@ -144,7 +144,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
     | **Operating System** section | Select **Windows** |
     | **Region** drop-down list | Select the **East US** region |
     | **Windows Plan (East US)** section | Select **Create new**, enter the value **ManagedPlan** in the **Name** text box, and then select **OK** |
-    | **Pricing plan** section | Retain the default value |
+    | **Pricing plan** section | Select **Standard S1** |
 
     The following screenshot displays the configured settings on the **Create web app** blade.
 


### PR DESCRIPTION
# Module/Lab: 1

Fixes #618 

Changes proposed in this pull request:

- Update instruction to choose "Standard S1" for the App Service plan as Azure always defaults Premium tier for the App Service plan.
