### PR TITLE
Portal changed Url to Default domain in web apps

### DIFF
--- a/Instructions/Labs/AZ-204_lab_01.md
+++ b/Instructions/Labs/AZ-204_lab_01.md
@@ -177,7 +177,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
 
 1. On the **App Service** blade in the Settings section, select the **Properties** link to view more information about App Services.
 
-1. To get the App Service's URL, go to the **Overview** link, copy the value from the **URL** section, and then paste it to Notepad. You’ll use this value later in the lab.
+1. To get the App Service's URL, go to the **Overview** link, copy the value from the **Default domain** section, and then paste it to Notepad. Prepend `https://` to the domain name in Notepad. You’ll use this value later in the lab. 
 
     > **Note**: At this point, the web server at this URL will return a placeholder webpage. You haven't deployed any code to the Web App yet. You'll deploy code to the Web App later in this lab.
 


### PR DESCRIPTION
# Module/Lab: 01

Changes proposed in this pull request:

Simple UI change. The portal now references Default domain instead of Url. this changes the reference and instructs learner to create a URL out of the domain.

![image](https://user-images.githubusercontent.com/89028299/228561334-f12df576-8eb4-4554-b4fe-6656046ad34f.png)

