### PR TITLE
Lab 8 - UI change from Url to Default domain

### DIFF
--- a/Instructions/Labs/AZ-204_lab_08.md
+++ b/Instructions/Labs/AZ-204_lab_08.md
@@ -151,7 +151,7 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
 
 1.  Switch back to the browser window that displays the **httpapi**_[yourname]_ web app.
 
-1.  On the **App Service Overview** blade, in the **Essentials**, record the value of the **URL** link. You'll use this value later in the lab to send requests to the corresponding API.
+1.  On the **App Service Overview** blade, in the **Essentials**, record the value of the **Default domain** link. You'll use this value later in the lab to send requests to the corresponding API.
 
 #### Review
 


### PR DESCRIPTION
# Module/Lab: 08

Changes proposed in this pull request:

- Simple change to match small portal update where Url is now referenced as Default domain

![image](https://user-images.githubusercontent.com/89028299/228564227-27340d6f-43aa-45f0-970f-f8fb634a1c4a.png)

