### PR TITLE
LAB 02 - EX 04 - TASK 04 - STEPS 05/06 : Missed STATIC keyword

### DIFF
--- a/Instructions/Labs/AZ-204_lab_02.md
+++ b/Instructions/Labs/AZ-204_lab_02.md
@@ -408,14 +408,14 @@ In this exercise, you created a basic function that echoes the content sent thro
 
     ```csharp
     [FunctionName("Recurring")]
-    public void Run([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, ILogger log)
+    public static void Run([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, ILogger log)
     ```
 
 1. Update the **Run** method signature code block to change the schedule to run once every **30 seconds**:
 
     ```csharp
     [FunctionName("Recurring")]
-    public void Run([TimerTrigger("*/30 * * * * *")]TimerInfo myTimer, ILogger log)
+    public static void Run([TimerTrigger("*/30 * * * * *")]TimerInfo myTimer, ILogger log)
     ```
 
 1. Select **Save** to save your changes to the **Recurring.cs** file.


### PR DESCRIPTION
# Module/Lab: 02

LAB 02 - EX 04 - TASK 04 - STEPS 05/06 : In these steps there are the code for the Run method (the TimerTrigger function) without the `static` keyword. because the whole class is static, is mandatory to have static keyword there, otherwise the student will receive an build error during build process on Task 05 Step 03.

Changes proposed in this pull request:

- Added static keyword on code
