### PR TITLE
Lab 03: Remove typo in "terminal"

### DIFF
--- a/Instructions/Labs/AZ-204_lab_03.md
+++ b/Instructions/Labs/AZ-204_lab_03.md
@@ -171,7 +171,7 @@ In this exercise, you created placeholder containers in the Storage account, and
 
     > **Note**: The **dotnet new** command will create a new **console** project in a folder with the same name as the project.
 
-1. In the terninal, run the following command to import version 12.12.0 of **Azure.Storage.Blobs** from NuGet:
+1. In the terminal, run the following command to import version 12.12.0 of **Azure.Storage.Blobs** from NuGet:
 
     ```
     dotnet add package Azure.Storage.Blobs --version 12.12.0


### PR DESCRIPTION
# Module/Lab: 03

Fixes #665 .

Changes proposed in this pull request:

- Remove typo in word `terminal`

### Relevant Issues link
#665 