### PR TITLE
LAB01 - EX01 - TASK 02 - STEP08 : Command "show all keys" disappeared from UI

### DIFF
--- a/Instructions/Labs/AZ-204_lab_01.md
+++ b/Instructions/Labs/AZ-204_lab_01.md
@@ -87,9 +87,7 @@ In this lab, you will explore how to create a web application on Azure by using 
 
 1. On the **Storage account** blade, in the **Security + networking** section, select **Access keys**.
 
-1. On the **Access keys** blade, select **Show keys**.
-
-1. Review any one of the keys, and then copy the value of either of the **Connection string** boxes to the clipboard.
+1. On the **Access keys** blade, review any one of the keys (using **Show** button), and then copy the value of either of the **Connection string** boxes to the clipboard.
 
     > **Note**: It doesn't matter which connection string you choose. They are interchangeable.
 


### PR DESCRIPTION
# Lab: 01
## Exercise: 01
### Task: 02
#### Step: 08

Changes proposed in this pull request:
The instructions tell to the student to click on "show all keys" command but this command disappeared from the UI. I change the instructions to use the "show" commands near the keys and connection strings.

