### PR TITLE
LAB 04 - EX 03 - TASK 01 - STEP 10 : change build web application with Context project

### DIFF
--- a/Instructions/Labs/AZ-204_lab_04.md
+++ b/Instructions/Labs/AZ-204_lab_04.md
@@ -335,7 +335,7 @@ In this exercise, you used the .NET SDK for Azure Cosmos DB to insert data into 
     dotnet add package Microsoft.Azure.Cosmos --version 3.28.0
     ```
 
-1. From the terminal prompt, run the following command to build the .NET web application:
+1. From the terminal prompt, run the following command to build the **AdventureWorks.Context** project:
 
     ```
     dotnet build


### PR DESCRIPTION
# Module/Lab: 04
## Exercise: 03
### Task:01
#### Step 10

Changes proposed in this pull request:

In the step 10 there is the sentence "... build the .NET web application" but in the context of the steps you are in the terminal of the Context project, not the web app. If the student follow the sentence and try to build the web app, he receives a build error.
