### PR TITLE
Corrected typo and grammar, updated links to learn.microsoft.com

### DIFF
--- a/Instructions/Labs/AZ-204_lab_09.md
+++ b/Instructions/Labs/AZ-204_lab_09.md
@@ -345,14 +345,14 @@ In this exercise, you created a new subscription, validated its registration, an
         Console.WriteLine("Second event published");
     }
     ```
-    > **Note**: For knowing more about **[AzureKeyCredential](https://docs.microsoft.com/dotnet/api/azure.azurekeycredential)**
+    > **Note**: To know more about **[AzureKeyCredential](https://docs.microsoft.com/dotnet/api/azure.azurekeycredential)**
   
-    > **Note**: For knowing more about Event Grid, click the blew links: 
-    - **[EventGridPublisherClient](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient)**
+    > **Note**: To know more about Event Grid, click the following links: 
+    - **[EventGridPublisherClient](https://learn.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient)**
     
-    - **[EventGridEvent](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridevent)**
+    - **[EventGridEvent](https://learn.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridevent)**
 
-    - **[EventGridPublisherClient.SendEventAsync](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient.sendeventasync)**
+    - **[EventGridPublisherClient.SendEventAsync](https://learn.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient.sendeventasync)**
 
 
 1. Save the **Program.cs** file.


### PR DESCRIPTION
Lab: 09: Publish and subscribe to Event Grid events

Fixes #697 

Changes proposed in this pull request:
- Typo "blew" instead of "blue" - changed to "following"
- Changed "For knowing more about" to "To know more about"- 
Updated links to learn.microsoft.com (not required, but since I'm on it ;-))