### PR TITLE
Lab 12 - Ensure public access is enabled

### DIFF
--- a/Instructions/Labs/AZ-204_lab_12.md
+++ b/Instructions/Labs/AZ-204_lab_12.md
@@ -55,7 +55,7 @@ In this lab, you will implement the Azure Content Delivery Network capabilities 
 
 1. On the **Storage accounts** blade, select **+ Create**.
 
-1. On the **Create a storage account** blade, on the **Basics** tab, perform the following actions, and then select **Review**.
+1. On the **Create a storage account** blade, on the **Basics** tab, perform the following actions.
 
    | Setting | Action |
    | -- | -- |
@@ -69,6 +69,8 @@ In this lab, you will implement the Azure Content Delivery Network capabilities 
     The following screenshot displays the configured settings in the **Create a storage account** blade.
 
     ![Screenshot displaying the configured settings on the Create a storage account blade](./media/l12_create_a_storage_account.png)
+
+1. On the **Advanced** tab, ensure **Allow enabling public access on individual containers** is enabled. Check the box if it is not enabled.
 
 1. On the **Review** tab, review the options that you selected during the previous steps.
 


### PR DESCRIPTION
# Module/Lab: 12

Changes proposed in this pull request:

- Recent Azure Storage Account defaults have changes in the portal. This ensures that the storage account used as the CDN source allows for public access.
-


