### PR TITLE
Application setting location change due to UI updation of Azure

### DIFF
--- a/Instructions/Labs/AZ-204_lab_01.md
+++ b/Instructions/Labs/AZ-204_lab_01.md
@@ -303,17 +303,16 @@ The following screenshot displays the configured settings on the **Create web ap
 
 #### Task 2: Configure a web app
 
-1. On the **App Service** blade, in the **Settings** section, select the **Configuration** link.
+1. On the **App Service** blade, in the **Settings** section, select the **Environment Variables** link.
 
-1. In the **Configuration** section, perform the following actions, select **Save**, and then select **Continue**:
+1. In the **Environment Variables** section, select **App Setting** and perform the following actions, select **Save**, and then select **Continue**:
 
    | Setting                                        | Action                                                                                                                                                                                                     |
    | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Application settings** tab                   | Select **New application setting**                                                                                                                                                                         |
-   | **Add/Edit application setting** pop-up dialog | In the **Name** text box, enter **ApiUrl**                                                                                                                                                                 |
+   | **Name** text box                              | In the **Name** text box, enter **ApiUrl**                                                                                                                                                                 |
    | **Value** text box                             | Enter the web app URL that you copied previously in this lab. **Note**: Make sure you include the protocol **https://**, in the URL that you copy into the **Value** text box for this application setting |
    | **Deployment slot setting** check box          | Retain the default value, and then select **OK**                                                                                                                                                           |
-    | **Click **Save** in the  top menu           | This will save the configuration value you just entered |
+    | **Click **Apply** option at the bottom        | This will save the configuration value you just entered |
 
    > **Note**: Wait for the application settings to save before you continue with this lab.
 


### PR DESCRIPTION
Now application setting option to save connection string shifted under Environment variables inside settings

# Module/Lab: 01

Fixes # .

Changes proposed in this pull request:

- Fixed change of application setting option due to change in Azure portal UI
-

### Relevant Issues link
