### PR TITLE
LAB 08 - LAB 09 : Add info for clarify steps to students

### DIFF
--- a/Instructions/Labs/AZ-204_lab_08.md
+++ b/Instructions/Labs/AZ-204_lab_08.md
@@ -66,7 +66,7 @@ In this proof of concept, you will create a containerized application to host a 
     | **Operating System** section | Select **Linux** |
     | **Region** drop-down list | Select any Azure region in which you can deploy an Azure web app |
     | **Linux Plan** section | Select **Create new**, enter  the value **ApiPlan** in the **Name** text  box, and then select **OK** |
-    | **Pricing plan** section | Select **Explore pricing plans**, on the **Select App Service Pricing Plan** page, select **S1**, and then select **Select** |
+    | **Pricing plan** section | Select **Explore pricing plans**, on the **Select App Service Pricing Plan** page, select **Standard S1**, and then select **Select** |
 
 1. Select **Next: Docker >**.
 

--- a/Instructions/Labs/AZ-204_lab_09.md
+++ b/Instructions/Labs/AZ-204_lab_09.md
@@ -288,6 +288,7 @@ In this exercise, you created a new subscription, validated its registration, an
         }
     }
     ```
+> **Note**: In the previous code, change the string **&lt;topic-endpoint&gt;** with the topic endpoint saved earlier and the string **&lt;topic-key&gt;** with the access key.
 
 #### Task 3: Publish new events
 


### PR DESCRIPTION
# Module/Lab: 08
## EX 01
### Task 02
#### Step 03

Changes proposed in this pull request:

- Using "Standard S1" instead "S1" is more clear for the students because it is the label that appears in the list of the pricing tiers of the app service plan

# Module/Lab: 09
## EX 03
### Task 02
#### Step 03

Changes proposed in this pull request:

- The note can help students (especially students that are not expert with C#) to understand how they can use topic url and access key in the code.