### PR TITLE
Update AZ-204_lab_04.md

### DIFF
--- a/Instructions/Labs/AZ-204_lab_04.md
+++ b/Instructions/Labs/AZ-204_lab_04.md
@@ -71,7 +71,7 @@ Finally, you will set the consistency level for your Cosmos DB instance and impl
    | **Resource group** section  | Select **Create new**                                                                                                    |
    | **Name** text box           | Enter **Polyglotdata** and select **OK**                                                                                 |
    | **AccountName** text box    | Enter **polycosmos**_[yourname]_                                                                                         |
-   | **Location** drop-down list | Select an Azure region that is closest to the location of your lab computer and where you can create a Cosmos DB account |
+   | **Location** drop-down list | Enter **(US) East US**                                                                                                   |
    | **Capacity mode** section   | Select **Serverless**                                                                                                    |
 
    The following screenshot displays the configured settings on the **Create Azure Cosmos DB Account - Azure Cosmos DB for NoSQL** page.


### PR DESCRIPTION
When defining the location the ALH (Authorized Lab Hoster) is using the region '(US) East US'. 

Skillable and go deploy requires the '(US) East US' region. XtremeLabs allow to use the default region '(US) West US 3' or '(US) East US'.

# Module/Lab: 04: Construct a polyglot data solution

Fixes # .

Changes proposed in this pull request:

- Define the region to use.

### Relevant Issues link
