### PR TITLE
fix(ImagesControllers.cs): unused variable in ImagesController.Get method

### DIFF
--- a/Allfiles/Labs/01/Starter/API/Controllers/ImagesController.cs
+++ b/Allfiles/Labs/01/Starter/API/Controllers/ImagesController.cs
@@ -36,7 +36,6 @@ namespace Api.Controllers
         public async Task<ActionResult<IEnumerable<string>>> Get()
         {
             BlobContainerClient containerClient = await GetCloudBlobContainer(_options.FullImageContainerName);
-            BlobServiceClient blobServiceClient = new BlobServiceClient(_options.StorageConnectionString);
 
             BlobClient blobClient;
             BlobSasBuilder blobSasBuilder;


### PR DESCRIPTION
# Module/Lab: 01

This fix is just about an unsed variable in `ImagesController.Get` method.
There is no need to instantiate `BlobServiceClient` again.
