### PR TITLE
Lab 06: Corrected cloud shell instructions for PS/Bash

### DIFF
--- a/Instructions/Labs/AZ-204_lab_06.md
+++ b/Instructions/Labs/AZ-204_lab_06.md
@@ -108,7 +108,7 @@ In this lab, you will register an application in Microsoft Entra ID, add a user,
 
 #### Task 5: Create a Microsoft Entra ID user
 
-1. In the Azure portal, select the **Cloud Shell** icon ![Cloud Shell icon](./media/az204_lab_CloudShell.png) to open a the Cloud Shell. If Cloud Shell defaults to a PowerShell session, select **Switch to Bash** in the **Cloud Shell** menu and then select **Confirm**.
+1. In the Azure portal, select the **Cloud Shell** icon ![Cloud Shell icon](./media/az204_lab_CloudShell.png) to open a the Cloud Shell. If Cloud Shell defaults to a Bash session, select **Switch to PowerShell** in the **Cloud Shell** menu and then select **Confirm**.
 
     > **Note**: The **Cloud Shell** icon is represented by a greater than sign (\>) and underscore character (\_).
 
@@ -116,7 +116,7 @@ In this lab, you will register an application in Microsoft Entra ID, add a user,
 
     | Prompt | Action |
     |--|--|
-    | Welcome to Azure Cloud Shell | Select **Bash**. |
+    | Welcome to Azure Cloud Shell | Select **PowerShell**. |
     | Getting Started | Select **Mount storage account**, then select your **Storage account subscription** from the drop-down, and finally select **Apply**. |
     | Mount storage account | Select **We will create a storage account for you**, and then select **Next**. |
 


### PR DESCRIPTION
The instructions mention to select Bash for the shell but proceeds to provide PowerShell commands.

# Module/Lab: 06

Fixes #802  .

Changes proposed in this pull request:

- Correct `Bash` to `PowerShell` for an exercise that requires running PowerShell commands.
