### PR TITLE
Replace markdown for CURL statements

### DIFF
--- a/Instructions/Labs/AZ-204_lab_02.md
+++ b/Instructions/Labs/AZ-204_lab_02.md
@@ -288,25 +288,25 @@ In this exercise, you created a local project that you'll use for Azure Function
 
 1. Run the following command to run test the **POST** REST API call against `http://localhost:7071/api/echo` with HTTP request body set to a numeric value of **3**:
 
-   ```powershell
+   ```cmd
    curl -X POST -i http://localhost:7071/api/echo -d 3
    ```
 
 1. Run the following command to test the **POST** REST API call against `http://localhost:7071/api/echo` with HTTP request body set to a numeric value of **5**:
 
-   ```powershell
+   ```cmd
    curl -X POST -i http://localhost:7071/api/echo -d 5
    ```
 
 1. Run the following command to test the **POST** REST API call against `http://localhost:7071/api/echo` with HTTP request body set to a string value of **Hello**:
 
-   ```powershell
+   ```cmd
    curl -X POST -i http://localhost:7071/api/echo -d "Hello"
    ```
 
 1. Run the following command to test the **POST** REST API call against `http://localhost:7071/api/echo` with HTTP request body set to a JavaScript Object Notation (JSON) value of **{"msg": "Successful"}**:
 
-   ```powershell
+   ```cmd
    curl -X POST -i http://localhost:7071/api/echo -d "{"msg": "Successful"}"
    ```
 
@@ -542,7 +542,7 @@ In this exercise, you created a function that runs automatically based on a fixe
 
 1. Run the following command to test the **GET** REST API call against `http://localhost:7071/api/GetSettingInfo`:
 
-   ```powershell
+   ```cmd
    curl -X GET -i http://localhost:7071/api/GetSettingInfo
    ```
 

--- a/Instructions/Labs/AZ-204_lab_07.md
+++ b/Instructions/Labs/AZ-204_lab_07.md
@@ -446,13 +446,13 @@ In this exercise, you created a system-assigned managed service identity for you
 
 1. Run the following command to run test the **GET** REST API call against `http://localhost:7071/api/FileParser`:
 
-   ```powershell
+   ```cmd
    curl -X GET -i http://localhost:7071/api/FileParser
    ```
 
 1. Observe the **[TEST VALUE]** value of the **StorageConnectionString** being returned as the result of the HTTP request:
 
-   ```powershell
+   ```cmd
    HTTP/1.1 200 OK
    Content-Type: text/plain; charset=utf-8
    Date: Tue, 01 Sep 2020 23:35:39 GMT


### PR DESCRIPTION
# Module/Lab: 02 / 07

I've had a few students comment that the lab 02 and 07 has the students open a command prompt to run the curl statements but the markdown just uses our copy/pasted \`\`\`powershell.

I change the affected labs to have cmd instead of powershell for those statements.